### PR TITLE
Methane RCS options

### DIFF
--- a/GameData/NearFutureLaunchVehicles/Localization/en-us.cfg
+++ b/GameData/NearFutureLaunchVehicles/Localization/en-us.cfg
@@ -442,6 +442,12 @@ Localization
     #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-3x-1_title = AVCS-CH4-3 Integrated RCS Block
     #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-3x-1_description = The Advanced Vehicle Cogeneration System provides an integrated system to reduce the complexity of launch vehicle upper stages. By tapping the main vehicle's fuel systems for gas that would normally be vented, a small fuel cell generator can be operated and used to drive miniature RCS jets. The result is a highly mass-efficient but expensive generator, battery and reaction control system. This model has 3 nozzles and operates using Liqud Hydrogen and Oxidizer. 
 
+	#LOC_NFLaunchVehicles_switcher_rcs_desc = RCS Propellant
+	#LOC_NFLaunchVehicles_switcher_rcs_desc_plural = RCS Propellant Options
+    #LOC_NFLaunchVehicles_switcher_rcs_detail_lfo =  #Uses LiquidFuel and Oxidizer.<br><b>Thruster Power:</b> $/ThrustLF$<br><b>Isp:</b> $/IspASLLF$s (ASL) / $/IspVacLF$s (Vac).
+    #LOC_NFLaunchVehicles_switcher_rcs_detail_lh2o =  #Uses LqdHydrogen and Oxidizer.<br><b>Thruster Power:</b> $/ThrustH2$<br><b>Isp:</b> $/IspASLH2$s (ASL) / $/IspVacH2$s (Vac).
+    #LOC_NFLaunchVehicles_switcher_rcs_detail_methox =  #Uses LqdMethane and Oxidizer.<br><b>Thruster Power:</b> $/ThrustCH4$<br><b>Isp:</b> $/IspASLCH4$s (ASL) / $/IspVacCH4$s (Vac).
+
     /// LEGACY DON'T LOOK PAST HERE AAAAAAA
     // OLD SWITCHERS
 

--- a/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesCryoTanksLCH4RCS.cfg
+++ b/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesCryoTanksLCH4RCS.cfg
@@ -1,5 +1,5 @@
 // LCH4 IVF RCS
-+PART[nflv-rcs-integrated-4x-1]:NEEDS[CryoTanks,CryoTanksMethalox,!ModularFuelTanks,!RealFuels]:AFTER[ZZZ_CRYOTANKS]
++PART[nflv-rcs-integrated-4x-1]:NEEDS[CryoTanks,!ModularFuelTanks,!RealFuels]:AFTER[ZZZ_CRYOTANKS]
 {
   @name = nflv-rcs-integrated-lch4-4x-1
   @title = #LOC_NFLaunchVehicles_nflv-rcs-integrated-lch4-4x-1_title

--- a/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesCryoTanksRCS.cfg
+++ b/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesCryoTanksRCS.cfg
@@ -1,0 +1,413 @@
+// LCH4/OX and LH2/OX options for the heavy bipropellant RCS, based on Starship Hot Gas RCS 
+
+@PART[nflv-rcs-heavy-1x-2]:NEEDS[CryoEngines,CryoTanks]:AFTER[ZZZ_CRYOTANKS]
+{
+	%IspVacLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$
+	%IspASLLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$
+	%ThrustLF = #$/MODULE[ModuleRCSFX]/thrusterPower$
+
+	%IspVacH2 = 380
+	%IspASLH2 = 152
+	%ThrustH2 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustH2 *= 0.5
+	
+	%IspVacCH4 = 300
+	%IspASLCH4 = 170
+	%ThrustCH4 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustCH4 *= 0.8
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = RCS
+		switcherDescription = #LOC_NFLaunchVehicles_switcher_rcs_desc
+		switcherDescriptionPlural =  #LOC_NFLaunchVehicles_switcher_rcs_desc_plural
+		switchInFlight = False
+		SUBTYPE
+		{
+			name = LFO
+			title = #LOC_CryoTanks_switcher_fuel_lfox 
+			primaryColor = ResourceColorLiquidFuel
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lfo
+
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustLF$
+					PROPELLANT
+					{
+						name = LiquidFuel
+						ratio = 0.45
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.55
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacLF$
+						key = #1 $/IspASLLF$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Hydrolox
+			title = #LOC_CryoTanks_switcher_fuel_lh2ox 
+			primaryColor = ResourceColorLqdHydrogen
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lh2o
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustH2$ 
+					PROPELLANT
+					{
+						name = LqdHydrogen
+						ratio = 1.5
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacH2$
+						key = #1 $/IspASLH2$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Methox
+			title = #LOC_CryoTanks_switcher_fuel_methalox 
+			primaryColor = ResourceColorLqdMethane
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_methox
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustCH4$ 
+					PROPELLANT
+					{
+						name = LqdMethane
+						ratio = 3
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacCH4$
+						key = #1 $/IspASLCH4$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+	}
+}
+
+@PART[nflv-rcs-heavy-4x-2]:NEEDS[CryoEngines,CryoTanks]:AFTER[ZZZ_CRYOTANKS]
+{
+	%IspVacLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$
+	%IspASLLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$
+	%ThrustLF = #$/MODULE[ModuleRCSFX]/thrusterPower$
+
+	%IspVacH2 = 380
+	%IspASLH2 = 152
+	%ThrustH2 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustH2 *= 0.5
+	
+	%IspVacCH4 = 300
+	%IspASLCH4 = 170
+	%ThrustCH4 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustCH4 *= 0.8
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = RCS
+		switcherDescription = #LOC_NFLaunchVehicles_switcher_rcs_desc
+		switcherDescriptionPlural =  #LOC_NFLaunchVehicles_switcher_rcs_desc_plural
+		switchInFlight = False
+		SUBTYPE
+		{
+			name = LFO
+			title = #LOC_CryoTanks_switcher_fuel_lfox 
+			primaryColor = ResourceColorLiquidFuel
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lfo
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustLF$
+					PROPELLANT
+					{
+						name = LiquidFuel
+						ratio = 0.45
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.55
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacLF$
+						key = #1 $/IspASLLF$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Hydrolox
+			title = #LOC_CryoTanks_switcher_fuel_lh2ox 
+			primaryColor = ResourceColorLqdHydrogen
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lh2o
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustH2$ 
+					PROPELLANT
+					{
+						name = LqdHydrogen
+						ratio = 1.5
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacH2$
+						key = #1 $/IspASLH2$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Methox
+			title = #LOC_CryoTanks_switcher_fuel_methalox 
+			primaryColor = ResourceColorLqdMethane
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_methox
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustCH4$ 
+					PROPELLANT
+					{
+						name = LqdMethane
+						ratio = 3
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacCH4$
+						key = #1 $/IspASLCH4$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+	}
+}
+
+@PART[nflv-rcs-aero-heavy-2]:NEEDS[CryoEngines,CryoTanks]:AFTER[ZZZ_CRYOTANKS]
+{
+	%IspVacLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$
+	%IspASLLF = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,1[1, ]$
+	%ThrustLF = #$/MODULE[ModuleRCSFX]/thrusterPower$
+
+	%IspVacH2 = 380
+	%IspASLH2 = 152
+	%ThrustH2 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustH2 *= 0.5
+	
+	%IspVacCH4 = 300
+	%IspASLCH4 = 170
+	%ThrustCH4 = #$/MODULE[ModuleRCSFX]/thrusterPower$
+	@ThrustCH4 *= 0.8
+
+	MODULE
+	{
+		name = ModuleB9PartSwitch
+		moduleID = RCS
+		switcherDescription = #LOC_NFLaunchVehicles_switcher_rcs_desc
+		switcherDescriptionPlural =  #LOC_NFLaunchVehicles_switcher_rcs_desc_plural
+		switchInFlight = False
+		SUBTYPE
+		{
+			name = LFO
+			title = #LOC_CryoTanks_switcher_fuel_lfox 
+			primaryColor = ResourceColorLiquidFuel
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lfo
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustLF$
+					PROPELLANT
+					{
+						name = LiquidFuel
+						ratio = 0.45
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.55
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacLF$
+						key = #1 $/IspASLLF$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Hydrolox
+			title = #LOC_CryoTanks_switcher_fuel_lh2ox 
+			primaryColor = ResourceColorLqdHydrogen
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_lh2o
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustH2$ 
+					PROPELLANT
+					{
+						name = LqdHydrogen
+						ratio = 1.5
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 0.1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacH2$
+						key = #1 $/IspASLH2$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+		SUBTYPE
+		{
+			name = Methox
+			title = #LOC_CryoTanks_switcher_fuel_methalox 
+			primaryColor = ResourceColorLqdMethane
+			secondaryColor = ResourceColorOxidizer
+      		descriptionDetail = #LOC_NFLaunchVehicles_switcher_rcs_detail_methox
+			MODULE
+			{
+				IDENTIFIER
+				{
+					name = ModuleRCSFX
+				}
+				DATA
+				{
+					thrusterPower = #$/ThrustCH4$ 
+					PROPELLANT
+					{
+						name = LqdMethane
+						ratio = 3
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					PROPELLANT
+					{
+						name = Oxidizer
+						ratio = 1
+						resourceFlowMode = STAGE_PRIORITY_FLOW
+					}
+					atmosphereCurve
+					{
+						key = #0 $/IspVacCH4$
+						key = #1 $/IspASLCH4$
+						key = 4 0.001
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two changes:
1) Fixes the IVF fuel cell methane variant. (It used to require CryoTanksMethalox, but that isn't a thing anymore since the methalox tanks got rolled into the main CryoTanks module)
2) Option to switch the bipropellant RCS to use any of LiquidFuel, LqdHydrogen, or LqdMethane (with the usual specific impulse vs thrust tradeoffs). Performance numbers for methox variant based on a SWAG at what the Starship hot gas RCS thruster is producing, performance numbers for hydrox are basically made up. (English localization included.)