### PR TITLE
Remove duplicated properties on skeletal adapters

### DIFF
--- a/GameData/NearFutureLaunchVehicles/Parts/FuelTank/nflv-skeletal-adapter-5-375-1.cfg
+++ b/GameData/NearFutureLaunchVehicles/Parts/FuelTank/nflv-skeletal-adapter-5-375-1.cfg
@@ -45,17 +45,6 @@ PART
 	breakingTorque = 350
 
 
-  // Parameters
-	mass = 1.5
-	dragModelType = default
-	maximum_drag = 0.2
-	minimum_drag = 0.3
-	angularDrag = 2
-	crashTolerance = 6
-	maxTemp = 2000
-	breakingForce = 350
-	breakingTorque = 350
-
 	// Resources
 	RESOURCE
 	{

--- a/GameData/NearFutureLaunchVehicles/Parts/FuelTank/nflv-skeletal-adapter-75-5-1.cfg
+++ b/GameData/NearFutureLaunchVehicles/Parts/FuelTank/nflv-skeletal-adapter-75-5-1.cfg
@@ -45,17 +45,6 @@ PART
 	breakingTorque = 350
 
 
-  // Parameters
-	mass = 1.5
-	dragModelType = default
-	maximum_drag = 0.2
-	minimum_drag = 0.3
-	angularDrag = 2
-	crashTolerance = 6
-	maxTemp = 2000
-	breakingForce = 350
-	breakingTorque = 350
-
 	// Resources
 	RESOURCE
 	{


### PR DESCRIPTION
Certainly shouldn't have been there.